### PR TITLE
Add Authorization Header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Here is a typical example of hitting a site 5 times
 howfast -s https://google.com -t 5
 ```
 
-By default, this will also generate a json file with all of the metrics you would need to do more detailed analysis. Upon completing the runs, it will open this file automatically for you. By default, this file is stored in `/tmp`, but can be modifying with the `-f` flag
+Here is an example of hitting a site that requires an Authorization header
+
+```
+howfast -s https://google.com -a 'Basic aG93ZmFzdDpyb2Nrcw=='
+```
+
+By default, this will also generate a json file with all of the metrics you would need to do more detailed analysis. Upon completing the runs, it will open this file automatically for you. By default, this file is stored in `/tmp`, but can be modified with the `-f` flag.
 
 ```
 howfast -s https://google.com -t 5 -f ~/Downloads

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,6 +18,12 @@ const options = yargs
     type: "number",
     default: 3,
   })
+  .option("a", {
+    alias: "auth",
+    describe: "The value of the Authorization header to pass to your site (if it requires one)",
+    type: "string",
+    default: "",
+  })
   .option("v", {
     alias: "verbose",
     describe: "Increase logging output",

--- a/lib/pagespeed.js
+++ b/lib/pagespeed.js
@@ -17,13 +17,14 @@ const median = (values) => {
   return (values[half - 1] + values[half]) / 2.0;
 };
 
-const getMetrics = async function (site, { verbose }) {
+const getMetrics = async function (site, { verbose, auth }) {
   const chrome = await chromeLauncher.launch({ chromeFlags: ["--headless"] });
   const lhOptions = {
     logLevel: verbose ? "info" : "error",
     output: "json",
     onlyCategories: ["performance"],
     port: chrome.port,
+    ...(auth ? { extraHeaders: { Authorization: auth } }: {}),
   };
   const runnerResult = await lighthouse(site, lhOptions, lhCustomConfig);
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   ],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tallnerds/howfast.git"
+  },
   "dependencies": {
     "chalk": "^4.1.0",
     "chrome-launcher": "^0.13.4",


### PR DESCRIPTION
- Add `Authorization` header CLI argument and support, which allows Lighthouse to hit sites that require it.  For example, sites behind basic auth.
- Add `repository` object to `package.json`.
- Update `README`.