### PR TITLE
feat: add requested url to json output

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -33,6 +33,10 @@ const metricSummary = function (metrics) {
 Average performance`)
   );
 
+  if (metrics.hasOwnProperty("requestedUrl")) {
+    delete metrics["requestedUrl"];
+  }
+
   _.forEach(
     metrics,
     ({ label, metricUnit, average: { score, numericValue } }) => {

--- a/lib/renderReport.js
+++ b/lib/renderReport.js
@@ -81,6 +81,7 @@ const renderReport = (metrics, { times, filepath, site, ...options }) => {
   const outputFile = `${filepath}/${
     parser.parse(site).hostname
   }-report-${new Date().toISOString()}.${options.html ? "html" : "json"}`;
+  metrics["requestedUrl"] = site;
 
   let output = JSON.stringify(metrics);
   if (options.html) {


### PR DESCRIPTION
Ref: #6 

Not sure if you're taking contributions. But I thought at least this would help you see what I was asking about.

Added `requestedUrl` to json output to increase longevity of report usefulness. After I ran about 100 reports and started looking through the json files, I realized I had no way of knowing which report went with which URL. This PR attempts to solve that.

Sample JSON output:
```json
{"performanceScore":{"label":"Performance Score","scorePath":"lhr.categories.performance.score","average":{"score":"97","numericValue":null},"median":{"score":97,"numericValue":null},"actual":{"scores":[97],"numericValues":null}},"firstContentfulPaint":{"label":"First Contentful Paint","scorePath":"lhr.audits.first-contentful-paint.score","metricPath":"lhr.audits.first-contentful-paint.numericValue","metricUnit":"ms","average":{"score":"98","numericValue":"1712.18"},"median":{"score":98,"numericValue":1712.179},"actual":{"scores":[98],"numericValues":[1712.179]}},"largestContentfulPaint":{"label":"Largest Contentful Paint","scorePath":"lhr.audits.largest-contentful-paint.score","metricPath":"lhr.audits.largest-contentful-paint.numericValue","metricUnit":"ms","average":{"score":"99","numericValue":"1778.04"},"median":{"score":99,"numericValue":1778.0415000000003},"actual":{"scores":[99],"numericValues":[1778.0415000000003]}},"speedIndex":{"label":"Speed Index","scorePath":"lhr.audits.speed-index.score","metricPath":"lhr.audits.speed-index.numericValue","metricUnit":"ms","average":{"score":"99","numericValue":"2129.71"},"median":{"score":99,"numericValue":2129.706489994024},"actual":{"scores":[99],"numericValues":[2129.706489994024]}},"cumulativeLayoutShift":{"label":"Cumulative Layout Shift","scorePath":"lhr.audits.cumulative-layout-shift.score","metricPath":"lhr.audits.cumulative-layout-shift.numericValue","average":{"score":"63","numericValue":"0.20"},"median":{"score":63,"numericValue":0.19568248155381943},"actual":{"scores":[63],"numericValues":[0.19568248155381943]}},"serverResponseTime":{"label":"Server Response Time","scorePath":"lhr.audits.server-response-time.score","metricPath":"lhr.audits.server-response-time.numericValue","metricUnit":"ms","average":{"score":"100","numericValue":"125.97"},"median":{"score":100,"numericValue":125.96699999999998},"actual":{"scores":[100],"numericValues":[125.96699999999998]}},"totalBlockingTime":{"label":"Total Blocking Time","scorePath":"lhr.audits.total-blocking-time.score","metricPath":"lhr.audits.total-blocking-time.numericValue","metricUnit":"ms","average":{"score":"100","numericValue":"9.00"},"median":{"score":100,"numericValue":8.999999999999886},"actual":{"scores":[100],"numericValues":[8.999999999999886]}},"requestedUrl":"https://jengermann.com"}
```