### PR TITLE
feat!: reformat json output to add options

### DIFF
--- a/lib/renderReport.js
+++ b/lib/renderReport.js
@@ -11,11 +11,7 @@ const generateMarkdown = (metrics, runs) => {
   for (let run = 1; run <= runs; run++) {
     const cols = [
       run,
-      _.get(
-        metrics,
-        `performanceScore.actual.scores.${run - 1}`,
-        0
-      ).toFixed(0),
+      _.get(metrics, `performanceScore.actual.scores.${run - 1}`, 0).toFixed(0),
       _.get(
         metrics,
         `firstContentfulPaint.actual.numericValues.${run - 1}`,
@@ -82,7 +78,7 @@ const renderReport = (metrics, { times, filepath, site, ...options }) => {
     parser.parse(site).hostname
   }-report-${new Date().toISOString()}.${options.html ? "html" : "json"}`;
 
-  let output = JSON.stringify(metrics);
+  let output = JSON.stringify({ metrics, options });
   if (options.html) {
     output = generateReport(templateFile, site, metrics, times);
   }


### PR DESCRIPTION

Should close #6 and close #7 

This PR will add passed in options to the json output for later parsing.

This will be a breaking change as the format of the json report will be keyed now.

**Before:**

```json
{
    "performanceScore": {
      "label": "Performance Score",
      "scorePath": "lhr.categories.performance.score",
      "average": {
        "score": "29",
        "numericValue": null
      },
      "median": {
        "score": 29,
        "numericValue": null
      },
      "actual": {
        "scores": [
          26,
          32
        ],
        "numericValues": null
      }
    }
}
```

**After:**

```json
{
  "metrics": {
    "performanceScore": {
      "label": "Performance Score",
      "scorePath": "lhr.categories.performance.score",
      "average": {
        "score": "29",
        "numericValue": null
      },
      "median": {
        "score": 29,
        "numericValue": null
      },
      "actual": {
        "scores": [
          26,
          32
        ],
        "numericValues": null
      }
    }
},
"options": {
    "_": [],
    "s": "https://www.bankrate.com/real-estate/",
    "t": 2,
    "f": "/Users/cconey/Downloads",
    "json": true,
    "a": "",
    "auth": "",
    "v": false,
    "verbose": false,
    "$0": "howfast"
  }

```